### PR TITLE
feat: Epic FHIR integration with dual authentication

### DIFF
--- a/apps/gateway/Gateway.API.Tests/Contracts/Http/FhirHttpClientProviderTests.cs
+++ b/apps/gateway/Gateway.API.Tests/Contracts/Http/FhirHttpClientProviderTests.cs
@@ -1,0 +1,42 @@
+namespace Gateway.API.Tests.Contracts.Http;
+
+using Gateway.API.Contracts.Http;
+using NSubstitute;
+
+public class FhirHttpClientProviderTests
+{
+    [Test]
+    public async Task IFhirHttpClientProvider_GetAuthenticatedClientAsync_ReturnsHttpClient()
+    {
+        // Arrange
+        var provider = Substitute.For<IFhirHttpClientProvider>();
+        var expectedClient = new HttpClient();
+        provider.GetAuthenticatedClientAsync(Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(expectedClient));
+
+        // Act
+        var client = await provider.GetAuthenticatedClientAsync();
+
+        // Assert
+        await Assert.That(client).IsNotNull();
+        await Assert.That(client).IsSameReferenceAs(expectedClient);
+    }
+
+    [Test]
+    public async Task IFhirHttpClientProvider_GetAuthenticatedClientAsync_AcceptsCancellationToken()
+    {
+        // Arrange
+        var provider = Substitute.For<IFhirHttpClientProvider>();
+        var cts = new CancellationTokenSource();
+        var expectedClient = new HttpClient();
+        provider.GetAuthenticatedClientAsync(cts.Token)
+            .Returns(Task.FromResult(expectedClient));
+
+        // Act
+        var client = await provider.GetAuthenticatedClientAsync(cts.Token);
+
+        // Assert
+        await Assert.That(client).IsSameReferenceAs(expectedClient);
+        await provider.Received(1).GetAuthenticatedClientAsync(cts.Token);
+    }
+}

--- a/apps/gateway/Gateway.API.Tests/Contracts/Http/TokenAcquisitionStrategyTests.cs
+++ b/apps/gateway/Gateway.API.Tests/Contracts/Http/TokenAcquisitionStrategyTests.cs
@@ -1,0 +1,36 @@
+namespace Gateway.API.Tests.Contracts.Http;
+
+using Gateway.API.Contracts.Http;
+using NSubstitute;
+
+public class TokenAcquisitionStrategyTests
+{
+    [Test]
+    public async Task ITokenAcquisitionStrategy_HasAcquireTokenAsyncMethod()
+    {
+        // Arrange
+        var strategy = Substitute.For<ITokenAcquisitionStrategy>();
+        strategy.AcquireTokenAsync(Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<string?>("test-token"));
+
+        // Act
+        var token = await strategy.AcquireTokenAsync();
+
+        // Assert
+        await Assert.That(token).IsEqualTo("test-token");
+    }
+
+    [Test]
+    public async Task ITokenAcquisitionStrategy_HasCanHandleProperty()
+    {
+        // Arrange
+        var strategy = Substitute.For<ITokenAcquisitionStrategy>();
+        strategy.CanHandle.Returns(true);
+
+        // Act
+        var canHandle = strategy.CanHandle;
+
+        // Assert
+        await Assert.That(canHandle).IsTrue();
+    }
+}

--- a/apps/gateway/Gateway.API.Tests/DependencyExtensionsTests.cs
+++ b/apps/gateway/Gateway.API.Tests/DependencyExtensionsTests.cs
@@ -1,0 +1,143 @@
+using Gateway.API.Contracts.Http;
+using Gateway.API.Services.Http;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Gateway.API.Tests;
+
+/// <summary>
+/// Tests for DependencyExtensions DI registration methods.
+/// </summary>
+public class DependencyExtensionsTests
+{
+    private static IConfiguration CreateConfiguration(
+        string fhirBaseUrl = "https://fhir.example.com/",
+        string clientId = "test-client",
+        string? tokenEndpoint = "https://auth.example.com/token")
+    {
+        var config = new Dictionary<string, string?>
+        {
+            ["Epic:FhirBaseUrl"] = fhirBaseUrl,
+            ["Epic:ClientId"] = clientId,
+            ["Epic:TokenEndpoint"] = tokenEndpoint,
+            ["ClinicalQuery:ObservationLookbackMonths"] = "12",
+            ["ClinicalQuery:ProcedureLookbackMonths"] = "24",
+            ["Document:PriorAuthLoincCode"] = "68552-9",
+            ["Document:PriorAuthLoincDisplay"] = "Prior Authorization",
+            ["Caching:Enabled"] = "false",
+            ["Caching:Duration"] = "00:05:00"
+        };
+
+        return new ConfigurationBuilder()
+            .AddInMemoryCollection(config)
+            .Build();
+    }
+
+    [Test]
+    public async Task AddEpicFhirServices_RegistersTokenStrategies()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+        var configuration = CreateConfiguration();
+        services.AddLogging();
+        services.AddHttpContextAccessor();
+        services.AddMemoryCache();
+
+        // Act
+        services.AddEpicFhirServices(configuration);
+        var provider = services.BuildServiceProvider();
+
+        // Assert
+        var cdsStrategy = provider.GetService<CdsHookTokenStrategy>();
+        var jwtStrategy = provider.GetService<JwtBackendTokenStrategy>();
+
+        await Assert.That(cdsStrategy).IsNotNull();
+        await Assert.That(jwtStrategy).IsNotNull();
+    }
+
+    [Test]
+    public async Task AddEpicFhirServices_RegistersTokenStrategyResolver()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+        var configuration = CreateConfiguration();
+        services.AddLogging();
+        services.AddHttpContextAccessor();
+        services.AddMemoryCache();
+
+        // Act
+        services.AddEpicFhirServices(configuration);
+        var provider = services.BuildServiceProvider();
+
+        // Assert
+        var resolver = provider.GetService<ITokenStrategyResolver>();
+        await Assert.That(resolver).IsNotNull();
+        await Assert.That(resolver).IsTypeOf<TokenStrategyResolver>();
+    }
+
+    [Test]
+    public async Task AddEpicFhirServices_RegistersFhirHttpClientProvider()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+        var configuration = CreateConfiguration();
+        services.AddLogging();
+        services.AddHttpContextAccessor();
+        services.AddMemoryCache();
+        services.AddHttpClient();
+
+        // Act
+        services.AddEpicFhirServices(configuration);
+        var provider = services.BuildServiceProvider();
+
+        // Assert
+        var clientProvider = provider.GetService<IFhirHttpClientProvider>();
+        await Assert.That(clientProvider).IsNotNull();
+        await Assert.That(clientProvider).IsTypeOf<FhirHttpClientProvider>();
+    }
+
+    [Test]
+    public async Task AddEpicFhirServices_RegistersEpicFhirOptionsWithValidation()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+        var configuration = CreateConfiguration();
+        services.AddLogging();
+        services.AddHttpContextAccessor();
+        services.AddMemoryCache();
+
+        // Act
+        services.AddEpicFhirServices(configuration);
+        var provider = services.BuildServiceProvider();
+
+        // Assert - Options should be resolvable
+        var options = provider.GetService<Microsoft.Extensions.Options.IOptions<Gateway.API.Configuration.EpicFhirOptions>>();
+        await Assert.That(options).IsNotNull();
+        await Assert.That(options!.Value).IsNotNull();
+        await Assert.That(options.Value.ClientId).IsEqualTo("test-client");
+        await Assert.That(options.Value.FhirBaseUrl).IsEqualTo("https://fhir.example.com/");
+    }
+
+    [Test]
+    public async Task AddEpicFhirServices_RegistersHttpClientNamedEpicFhir()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+        var configuration = CreateConfiguration();
+        services.AddLogging();
+        services.AddHttpContextAccessor();
+        services.AddMemoryCache();
+
+        // Act
+        services.AddEpicFhirServices(configuration);
+        var provider = services.BuildServiceProvider();
+
+        // Assert
+        var factory = provider.GetService<IHttpClientFactory>();
+        await Assert.That(factory).IsNotNull();
+
+        var client = factory!.CreateClient("EpicFhir");
+        await Assert.That(client).IsNotNull();
+        await Assert.That(client.BaseAddress?.ToString()).IsEqualTo("https://fhir.example.com/");
+    }
+}

--- a/apps/gateway/Gateway.API.Tests/Middleware/CdsHookTokenMiddlewareTests.cs
+++ b/apps/gateway/Gateway.API.Tests/Middleware/CdsHookTokenMiddlewareTests.cs
@@ -1,0 +1,180 @@
+using System.Text;
+using Gateway.API.Middleware;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+
+namespace Gateway.API.Tests.Middleware;
+
+/// <summary>
+/// Tests for CdsHookTokenMiddleware.
+/// </summary>
+public class CdsHookTokenMiddlewareTests
+{
+    private readonly ILogger<CdsHookTokenMiddleware> _logger;
+    private bool _nextCalled;
+
+    public CdsHookTokenMiddlewareTests()
+    {
+        _logger = Substitute.For<ILogger<CdsHookTokenMiddleware>>();
+        _nextCalled = false;
+    }
+
+    private RequestDelegate CreateNextDelegate()
+    {
+        return _ =>
+        {
+            _nextCalled = true;
+            return Task.CompletedTask;
+        };
+    }
+
+    [Test]
+    public async Task CdsHookTokenMiddleware_InvokeAsync_ExtractsTokenFromFhirAuthorization()
+    {
+        // Arrange
+        var context = CreateHttpContext("/cds-hooks/test", "POST", """
+            {
+                "hook": "order-select",
+                "fhirAuthorization": {
+                    "access_token": "extracted-fhir-token",
+                    "token_type": "Bearer",
+                    "expires_in": 3600
+                }
+            }
+            """);
+
+        var sut = new CdsHookTokenMiddleware(CreateNextDelegate(), _logger);
+
+        // Act
+        await sut.InvokeAsync(context);
+
+        // Assert
+        await Assert.That(context.Items.ContainsKey("FhirAccessToken")).IsTrue();
+        await Assert.That(context.Items["FhirAccessToken"]).IsEqualTo("extracted-fhir-token");
+    }
+
+    [Test]
+    public async Task CdsHookTokenMiddleware_InvokeAsync_SetsHttpContextItem()
+    {
+        // Arrange
+        const string expectedToken = "my-test-token-123";
+        var context = CreateHttpContext("/cds-hooks/order-sign", "POST", $$"""
+            {
+                "hook": "order-sign",
+                "fhirAuthorization": {
+                    "access_token": "{{expectedToken}}"
+                }
+            }
+            """);
+
+        var sut = new CdsHookTokenMiddleware(CreateNextDelegate(), _logger);
+
+        // Act
+        await sut.InvokeAsync(context);
+
+        // Assert
+        await Assert.That(context.Items["FhirAccessToken"]).IsEqualTo(expectedToken);
+        await Assert.That(_nextCalled).IsTrue();
+    }
+
+    [Test]
+    public async Task CdsHookTokenMiddleware_InvokeAsync_SkipsNonCdsHooksRequests()
+    {
+        // Arrange
+        var context = CreateHttpContext("/api/analysis", "POST", """
+            {
+                "fhirAuthorization": {
+                    "access_token": "should-not-extract"
+                }
+            }
+            """);
+
+        var sut = new CdsHookTokenMiddleware(CreateNextDelegate(), _logger);
+
+        // Act
+        await sut.InvokeAsync(context);
+
+        // Assert
+        await Assert.That(context.Items.ContainsKey("FhirAccessToken")).IsFalse();
+        await Assert.That(_nextCalled).IsTrue();
+    }
+
+    [Test]
+    public async Task CdsHookTokenMiddleware_InvokeAsync_SkipsGetRequests()
+    {
+        // Arrange
+        var context = CreateHttpContext("/cds-hooks/services", "GET", "");
+
+        var sut = new CdsHookTokenMiddleware(CreateNextDelegate(), _logger);
+
+        // Act
+        await sut.InvokeAsync(context);
+
+        // Assert
+        await Assert.That(context.Items.ContainsKey("FhirAccessToken")).IsFalse();
+        await Assert.That(_nextCalled).IsTrue();
+    }
+
+    [Test]
+    public async Task CdsHookTokenMiddleware_InvokeAsync_HandlesNullFhirAuthorization()
+    {
+        // Arrange
+        var context = CreateHttpContext("/cds-hooks/test", "POST", """
+            {
+                "hook": "order-select",
+                "context": {
+                    "patientId": "123"
+                }
+            }
+            """);
+
+        var sut = new CdsHookTokenMiddleware(CreateNextDelegate(), _logger);
+
+        // Act
+        await sut.InvokeAsync(context);
+
+        // Assert
+        await Assert.That(context.Items.ContainsKey("FhirAccessToken")).IsFalse();
+        await Assert.That(_nextCalled).IsTrue();
+    }
+
+    [Test]
+    public async Task CdsHookTokenMiddleware_InvokeAsync_HandlesInvalidJson()
+    {
+        // Arrange
+        var context = CreateHttpContext("/cds-hooks/test", "POST", "{ invalid json }");
+
+        var sut = new CdsHookTokenMiddleware(CreateNextDelegate(), _logger);
+
+        // Act
+        await sut.InvokeAsync(context);
+
+        // Assert
+        await Assert.That(context.Items.ContainsKey("FhirAccessToken")).IsFalse();
+        await Assert.That(_nextCalled).IsTrue();
+        _logger.Received(1).Log(
+            LogLevel.Warning,
+            Arg.Any<EventId>(),
+            Arg.Is<object>(o => o.ToString()!.Contains("Failed to parse")),
+            Arg.Any<Exception?>(),
+            Arg.Any<Func<object, Exception?, string>>());
+    }
+
+    private static DefaultHttpContext CreateHttpContext(string path, string method, string body)
+    {
+        var context = new DefaultHttpContext();
+        context.Request.Path = path;
+        context.Request.Method = method;
+
+        if (!string.IsNullOrEmpty(body))
+        {
+            var bytes = Encoding.UTF8.GetBytes(body);
+            context.Request.Body = new MemoryStream(bytes);
+            context.Request.ContentLength = bytes.Length;
+            context.Request.ContentType = "application/json";
+        }
+
+        return context;
+    }
+}

--- a/apps/gateway/Gateway.API.Tests/Services/Http/CdsHookTokenStrategyTests.cs
+++ b/apps/gateway/Gateway.API.Tests/Services/Http/CdsHookTokenStrategyTests.cs
@@ -1,0 +1,82 @@
+namespace Gateway.API.Tests.Services.Http;
+
+using Gateway.API.Services.Http;
+using Microsoft.AspNetCore.Http;
+using NSubstitute;
+
+public class CdsHookTokenStrategyTests
+{
+    [Test]
+    public async Task CdsHookTokenStrategy_CanHandle_ReturnsTrueWhenTokenInContext()
+    {
+        // Arrange
+        var httpContext = new DefaultHttpContext();
+        httpContext.Items["FhirAccessToken"] = "test-token";
+
+        var httpContextAccessor = Substitute.For<IHttpContextAccessor>();
+        httpContextAccessor.HttpContext.Returns(httpContext);
+
+        var strategy = new CdsHookTokenStrategy(httpContextAccessor);
+
+        // Act
+        var canHandle = strategy.CanHandle;
+
+        // Assert
+        await Assert.That(canHandle).IsTrue();
+    }
+
+    [Test]
+    public async Task CdsHookTokenStrategy_CanHandle_ReturnsFalseWhenNoToken()
+    {
+        // Arrange
+        var httpContext = new DefaultHttpContext();
+        // No FhirAccessToken in Items
+
+        var httpContextAccessor = Substitute.For<IHttpContextAccessor>();
+        httpContextAccessor.HttpContext.Returns(httpContext);
+
+        var strategy = new CdsHookTokenStrategy(httpContextAccessor);
+
+        // Act
+        var canHandle = strategy.CanHandle;
+
+        // Assert
+        await Assert.That(canHandle).IsFalse();
+    }
+
+    [Test]
+    public async Task CdsHookTokenStrategy_AcquireTokenAsync_ReturnsTokenFromContext()
+    {
+        // Arrange
+        const string expectedToken = "test-bearer-token";
+        var httpContext = new DefaultHttpContext();
+        httpContext.Items["FhirAccessToken"] = expectedToken;
+
+        var httpContextAccessor = Substitute.For<IHttpContextAccessor>();
+        httpContextAccessor.HttpContext.Returns(httpContext);
+
+        var strategy = new CdsHookTokenStrategy(httpContextAccessor);
+
+        // Act
+        var token = await strategy.AcquireTokenAsync();
+
+        // Assert
+        await Assert.That(token).IsEqualTo(expectedToken);
+    }
+
+    [Test]
+    public async Task CdsHookTokenStrategy_AcquireTokenAsync_ReturnsNullWhenNoContext()
+    {
+        // Arrange
+        var httpContextAccessor = Substitute.For<IHttpContextAccessor>();
+        httpContextAccessor.HttpContext.Returns((HttpContext?)null);
+
+        var strategy = new CdsHookTokenStrategy(httpContextAccessor);
+
+        // Act
+        var token = await strategy.AcquireTokenAsync();
+
+        // Assert
+        await Assert.That(token).IsNull();
+    }
+}

--- a/apps/gateway/Gateway.API.Tests/Services/Http/FhirHttpClientProviderTests.cs
+++ b/apps/gateway/Gateway.API.Tests/Services/Http/FhirHttpClientProviderTests.cs
@@ -1,0 +1,109 @@
+using System.Net.Http.Headers;
+using Gateway.API.Contracts.Http;
+using Gateway.API.Services.Http;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+
+namespace Gateway.API.Tests.Services.Http;
+
+/// <summary>
+/// Tests for FhirHttpClientProvider.
+/// </summary>
+public class FhirHttpClientProviderTests
+{
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly ITokenStrategyResolver _tokenResolver;
+    private readonly ILogger<FhirHttpClientProvider> _logger;
+    private readonly ITokenAcquisitionStrategy _mockStrategy;
+
+    public FhirHttpClientProviderTests()
+    {
+        _httpClientFactory = Substitute.For<IHttpClientFactory>();
+        _tokenResolver = Substitute.For<ITokenStrategyResolver>();
+        _logger = Substitute.For<ILogger<FhirHttpClientProvider>>();
+        _mockStrategy = Substitute.For<ITokenAcquisitionStrategy>();
+    }
+
+    [Test]
+    public async Task FhirHttpClientProvider_GetAuthenticatedClientAsync_UsesHttpClientFactory()
+    {
+        // Arrange
+        var expectedClient = new HttpClient();
+        _httpClientFactory.CreateClient("EpicFhir").Returns(expectedClient);
+        _tokenResolver.Resolve().Returns(_mockStrategy);
+        _mockStrategy.AcquireTokenAsync(Arg.Any<CancellationToken>()).Returns("test-token");
+
+        var sut = new FhirHttpClientProvider(_httpClientFactory, _tokenResolver, _logger);
+
+        // Act
+        var result = await sut.GetAuthenticatedClientAsync();
+
+        // Assert
+        _httpClientFactory.Received(1).CreateClient("EpicFhir");
+        await Assert.That(result).IsNotNull();
+    }
+
+    [Test]
+    public async Task FhirHttpClientProvider_GetAuthenticatedClientAsync_CallsTokenResolver()
+    {
+        // Arrange
+        var expectedClient = new HttpClient();
+        _httpClientFactory.CreateClient("EpicFhir").Returns(expectedClient);
+        _tokenResolver.Resolve().Returns(_mockStrategy);
+        _mockStrategy.AcquireTokenAsync(Arg.Any<CancellationToken>()).Returns("test-token");
+
+        var sut = new FhirHttpClientProvider(_httpClientFactory, _tokenResolver, _logger);
+
+        // Act
+        await sut.GetAuthenticatedClientAsync();
+
+        // Assert
+        _tokenResolver.Received(1).Resolve();
+        await _mockStrategy.Received(1).AcquireTokenAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Test]
+    public async Task FhirHttpClientProvider_GetAuthenticatedClientAsync_AttachesBearerToken()
+    {
+        // Arrange
+        const string expectedToken = "test-bearer-token";
+        var client = new HttpClient();
+        _httpClientFactory.CreateClient("EpicFhir").Returns(client);
+        _tokenResolver.Resolve().Returns(_mockStrategy);
+        _mockStrategy.AcquireTokenAsync(Arg.Any<CancellationToken>()).Returns(expectedToken);
+
+        var sut = new FhirHttpClientProvider(_httpClientFactory, _tokenResolver, _logger);
+
+        // Act
+        var result = await sut.GetAuthenticatedClientAsync();
+
+        // Assert
+        await Assert.That(result.DefaultRequestHeaders.Authorization).IsNotNull();
+        await Assert.That(result.DefaultRequestHeaders.Authorization!.Scheme).IsEqualTo("Bearer");
+        await Assert.That(result.DefaultRequestHeaders.Authorization!.Parameter).IsEqualTo(expectedToken);
+    }
+
+    [Test]
+    public async Task FhirHttpClientProvider_GetAuthenticatedClientAsync_LogsWarningWhenNoToken()
+    {
+        // Arrange
+        var client = new HttpClient();
+        _httpClientFactory.CreateClient("EpicFhir").Returns(client);
+        _tokenResolver.Resolve().Returns(_mockStrategy);
+        _mockStrategy.AcquireTokenAsync(Arg.Any<CancellationToken>()).Returns((string?)null);
+
+        var sut = new FhirHttpClientProvider(_httpClientFactory, _tokenResolver, _logger);
+
+        // Act
+        var result = await sut.GetAuthenticatedClientAsync();
+
+        // Assert
+        await Assert.That(result.DefaultRequestHeaders.Authorization).IsNull();
+        _logger.Received(1).Log(
+            LogLevel.Warning,
+            Arg.Any<EventId>(),
+            Arg.Is<object>(o => o.ToString()!.Contains("No access token")),
+            Arg.Any<Exception?>(),
+            Arg.Any<Func<object, Exception?, string>>());
+    }
+}

--- a/apps/gateway/Gateway.API.Tests/Services/Http/JwtBackendTokenStrategyTests.cs
+++ b/apps/gateway/Gateway.API.Tests/Services/Http/JwtBackendTokenStrategyTests.cs
@@ -1,0 +1,358 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Net;
+using System.Security.Cryptography;
+using System.Text.Json;
+using Gateway.API.Configuration;
+using Gateway.API.Services.Http;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Microsoft.IdentityModel.Tokens;
+using NSubstitute;
+
+namespace Gateway.API.Tests.Services.Http;
+
+public class JwtBackendTokenStrategyTests
+{
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly IMemoryCache _tokenCache;
+    private readonly ILogger<JwtBackendTokenStrategy> _logger;
+    private readonly string _testKeyPath;
+
+    public JwtBackendTokenStrategyTests()
+    {
+        _httpClientFactory = Substitute.For<IHttpClientFactory>();
+        _tokenCache = new MemoryCache(new MemoryCacheOptions());
+        _logger = Substitute.For<ILogger<JwtBackendTokenStrategy>>();
+
+        // Create a temporary RSA key file for testing
+        _testKeyPath = Path.Combine(Path.GetTempPath(), $"test-key-{Guid.NewGuid()}.pem");
+        using var rsa = RSA.Create(2048);
+        var privateKey = rsa.ExportRSAPrivateKeyPem();
+        File.WriteAllText(_testKeyPath, privateKey);
+    }
+
+    [After(Test)]
+    public Task Cleanup()
+    {
+        if (File.Exists(_testKeyPath))
+        {
+            File.Delete(_testKeyPath);
+        }
+        _tokenCache.Dispose();
+        return Task.CompletedTask;
+    }
+
+    private JwtBackendTokenStrategy CreateSut(EpicFhirOptions? options = null)
+    {
+        options ??= new EpicFhirOptions
+        {
+            FhirBaseUrl = "https://fhir.epic.com/api/FHIR/R4",
+            ClientId = "test-client-id",
+            TokenEndpoint = "https://fhir.epic.com/oauth2/token",
+            PrivateKeyPath = _testKeyPath,
+            SigningAlgorithm = "RS384"
+        };
+
+        return new JwtBackendTokenStrategy(
+            _httpClientFactory,
+            Options.Create(options),
+            _tokenCache,
+            _logger);
+    }
+
+    #region Task 006 Tests - JWT Generation
+
+    [Test]
+    public async Task JwtBackendTokenStrategy_CanHandle_AlwaysReturnsTrue()
+    {
+        // Arrange
+        var sut = CreateSut();
+
+        // Act
+        var result = sut.CanHandle;
+
+        // Assert
+        await Assert.That(result).IsTrue();
+    }
+
+    [Test]
+    public async Task JwtBackendTokenStrategy_GenerateClientAssertion_CreatesValidJwt()
+    {
+        // Arrange
+        var sut = CreateSut();
+
+        // Act
+        var jwt = sut.GenerateClientAssertion();
+
+        // Assert
+        await Assert.That(jwt).IsNotNull();
+        var handler = new JwtSecurityTokenHandler();
+        var canRead = handler.CanReadToken(jwt);
+        await Assert.That(canRead).IsTrue();
+    }
+
+    [Test]
+    public async Task JwtBackendTokenStrategy_GenerateClientAssertion_IncludesRequiredClaims()
+    {
+        // Arrange
+        var options = new EpicFhirOptions
+        {
+            FhirBaseUrl = "https://fhir.epic.com/api/FHIR/R4",
+            ClientId = "my-test-client",
+            TokenEndpoint = "https://fhir.epic.com/oauth2/token",
+            PrivateKeyPath = _testKeyPath,
+            SigningAlgorithm = "RS384"
+        };
+        var sut = CreateSut(options);
+
+        // Act
+        var jwt = sut.GenerateClientAssertion();
+
+        // Assert
+        var handler = new JwtSecurityTokenHandler();
+        var token = handler.ReadJwtToken(jwt);
+
+        // Check iss claim
+        var iss = token.Claims.FirstOrDefault(c => c.Type == JwtRegisteredClaimNames.Iss)?.Value;
+        await Assert.That(iss).IsEqualTo("my-test-client");
+
+        // Check sub claim
+        var sub = token.Claims.FirstOrDefault(c => c.Type == JwtRegisteredClaimNames.Sub)?.Value;
+        await Assert.That(sub).IsEqualTo("my-test-client");
+
+        // Check aud claim
+        var aud = token.Claims.FirstOrDefault(c => c.Type == JwtRegisteredClaimNames.Aud)?.Value;
+        await Assert.That(aud).IsEqualTo("https://fhir.epic.com/oauth2/token");
+
+        // Check jti claim (unique identifier)
+        var jti = token.Claims.FirstOrDefault(c => c.Type == JwtRegisteredClaimNames.Jti)?.Value;
+        await Assert.That(jti).IsNotNull();
+
+        // Verify jti is a valid GUID
+        var isValidGuid = Guid.TryParse(jti, out _);
+        await Assert.That(isValidGuid).IsTrue();
+
+        // Check exp claim exists and is in the future
+        var exp = token.Claims.FirstOrDefault(c => c.Type == JwtRegisteredClaimNames.Exp)?.Value;
+        await Assert.That(exp).IsNotNull();
+    }
+
+    [Test]
+    [Arguments("RS256", SecurityAlgorithms.RsaSha256)]
+    [Arguments("RS384", SecurityAlgorithms.RsaSha384)]
+    [Arguments("RS512", SecurityAlgorithms.RsaSha512)]
+    public async Task JwtBackendTokenStrategy_GenerateClientAssertion_SignsWithConfiguredAlgorithm(
+        string configAlgorithm,
+        string expectedAlgorithm)
+    {
+        // Arrange
+        var options = new EpicFhirOptions
+        {
+            FhirBaseUrl = "https://fhir.epic.com/api/FHIR/R4",
+            ClientId = "test-client-id",
+            TokenEndpoint = "https://fhir.epic.com/oauth2/token",
+            PrivateKeyPath = _testKeyPath,
+            SigningAlgorithm = configAlgorithm
+        };
+        var sut = CreateSut(options);
+
+        // Act
+        var jwt = sut.GenerateClientAssertion();
+
+        // Assert
+        var handler = new JwtSecurityTokenHandler();
+        var token = handler.ReadJwtToken(jwt);
+
+        await Assert.That(token.Header.Alg).IsEqualTo(expectedAlgorithm);
+    }
+
+    #endregion
+
+    #region Task 007 Tests - Token Exchange and Caching
+
+    [Test]
+    public async Task JwtBackendTokenStrategy_AcquireTokenAsync_ReturnsCachedToken()
+    {
+        // Arrange
+        var cache = new MemoryCache(new MemoryCacheOptions());
+        var expectedToken = "cached-access-token";
+        cache.Set("EpicAccessToken", expectedToken, TimeSpan.FromMinutes(55));
+
+        var options = new EpicFhirOptions
+        {
+            FhirBaseUrl = "https://fhir.epic.com/api/FHIR/R4",
+            ClientId = "test-client-id",
+            TokenEndpoint = "https://fhir.epic.com/oauth2/token",
+            PrivateKeyPath = _testKeyPath,
+            SigningAlgorithm = "RS384"
+        };
+
+        var sut = new JwtBackendTokenStrategy(
+            _httpClientFactory,
+            Options.Create(options),
+            cache,
+            _logger);
+
+        // Act
+        var result = await sut.AcquireTokenAsync();
+
+        // Assert
+        await Assert.That(result).IsEqualTo(expectedToken);
+
+        // Verify HTTP client was never called
+        _httpClientFactory.DidNotReceive().CreateClient(Arg.Any<string>());
+
+        cache.Dispose();
+    }
+
+    [Test]
+    public async Task JwtBackendTokenStrategy_AcquireTokenAsync_ExchangesJwtForToken()
+    {
+        // Arrange
+        var tokenResponse = new { access_token = "new-access-token", token_type = "Bearer", expires_in = 3600 };
+        var responseContent = JsonSerializer.Serialize(tokenResponse);
+
+        var mockHandler = new MockHttpMessageHandler(responseContent, HttpStatusCode.OK);
+        var httpClient = new HttpClient(mockHandler);
+
+        var httpClientFactory = Substitute.For<IHttpClientFactory>();
+        httpClientFactory.CreateClient(Arg.Any<string>()).Returns(httpClient);
+
+        var cache = new MemoryCache(new MemoryCacheOptions());
+        var options = new EpicFhirOptions
+        {
+            FhirBaseUrl = "https://fhir.epic.com/api/FHIR/R4",
+            ClientId = "test-client-id",
+            TokenEndpoint = "https://fhir.epic.com/oauth2/token",
+            PrivateKeyPath = _testKeyPath,
+            SigningAlgorithm = "RS384"
+        };
+
+        var sut = new JwtBackendTokenStrategy(
+            httpClientFactory,
+            Options.Create(options),
+            cache,
+            _logger);
+
+        // Act
+        var result = await sut.AcquireTokenAsync();
+
+        // Assert
+        await Assert.That(result).IsEqualTo("new-access-token");
+
+        // Verify the request was made to the token endpoint
+        await Assert.That(mockHandler.LastRequestUri?.ToString())
+            .IsEqualTo("https://fhir.epic.com/oauth2/token");
+
+        cache.Dispose();
+    }
+
+    [Test]
+    public async Task JwtBackendTokenStrategy_AcquireTokenAsync_CachesNewToken()
+    {
+        // Arrange
+        var tokenResponse = new { access_token = "new-access-token", token_type = "Bearer", expires_in = 3600 };
+        var responseContent = JsonSerializer.Serialize(tokenResponse);
+
+        var mockHandler = new MockHttpMessageHandler(responseContent, HttpStatusCode.OK);
+        var httpClient = new HttpClient(mockHandler);
+
+        var httpClientFactory = Substitute.For<IHttpClientFactory>();
+        httpClientFactory.CreateClient(Arg.Any<string>()).Returns(httpClient);
+
+        var cache = new MemoryCache(new MemoryCacheOptions());
+        var options = new EpicFhirOptions
+        {
+            FhirBaseUrl = "https://fhir.epic.com/api/FHIR/R4",
+            ClientId = "test-client-id",
+            TokenEndpoint = "https://fhir.epic.com/oauth2/token",
+            PrivateKeyPath = _testKeyPath,
+            SigningAlgorithm = "RS384"
+        };
+
+        var sut = new JwtBackendTokenStrategy(
+            httpClientFactory,
+            Options.Create(options),
+            cache,
+            _logger);
+
+        // Act
+        var result = await sut.AcquireTokenAsync();
+
+        // Assert - token is cached
+        var cachedToken = cache.Get<string>("EpicAccessToken");
+        await Assert.That(cachedToken).IsEqualTo("new-access-token");
+
+        cache.Dispose();
+    }
+
+    [Test]
+    public async Task JwtBackendTokenStrategy_AcquireTokenAsync_ReturnsNullOnError()
+    {
+        // Arrange
+        var mockHandler = new MockHttpMessageHandler("Internal Server Error", HttpStatusCode.InternalServerError);
+        var httpClient = new HttpClient(mockHandler);
+
+        var httpClientFactory = Substitute.For<IHttpClientFactory>();
+        httpClientFactory.CreateClient(Arg.Any<string>()).Returns(httpClient);
+
+        var cache = new MemoryCache(new MemoryCacheOptions());
+        var options = new EpicFhirOptions
+        {
+            FhirBaseUrl = "https://fhir.epic.com/api/FHIR/R4",
+            ClientId = "test-client-id",
+            TokenEndpoint = "https://fhir.epic.com/oauth2/token",
+            PrivateKeyPath = _testKeyPath,
+            SigningAlgorithm = "RS384"
+        };
+
+        var sut = new JwtBackendTokenStrategy(
+            httpClientFactory,
+            Options.Create(options),
+            cache,
+            _logger);
+
+        // Act
+        var result = await sut.AcquireTokenAsync();
+
+        // Assert
+        await Assert.That(result).IsNull();
+
+        cache.Dispose();
+    }
+
+    #endregion
+
+    /// <summary>
+    /// Mock HTTP message handler for testing HTTP requests.
+    /// </summary>
+    private sealed class MockHttpMessageHandler : HttpMessageHandler
+    {
+        private readonly string _response;
+        private readonly HttpStatusCode _statusCode;
+
+        public Uri? LastRequestUri { get; private set; }
+        public HttpContent? LastRequestContent { get; private set; }
+
+        public MockHttpMessageHandler(string response, HttpStatusCode statusCode)
+        {
+            _response = response;
+            _statusCode = statusCode;
+        }
+
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            LastRequestUri = request.RequestUri;
+            LastRequestContent = request.Content;
+
+            await Task.Yield();
+            return new HttpResponseMessage(_statusCode)
+            {
+                Content = new StringContent(_response, System.Text.Encoding.UTF8, "application/json")
+            };
+        }
+    }
+}

--- a/apps/gateway/Gateway.API/Configuration/EpicFhirOptions.cs
+++ b/apps/gateway/Gateway.API/Configuration/EpicFhirOptions.cs
@@ -29,4 +29,14 @@ public sealed class EpicFhirOptions
     /// Token endpoint for client credentials flow.
     /// </summary>
     public string? TokenEndpoint { get; init; }
+
+    /// <summary>
+    /// Path to the private key file for JWT signing.
+    /// </summary>
+    public string? PrivateKeyPath { get; init; }
+
+    /// <summary>
+    /// Signing algorithm for JWT (RS256, RS384, RS512). Defaults to RS384.
+    /// </summary>
+    public string SigningAlgorithm { get; init; } = "RS384";
 }

--- a/apps/gateway/Gateway.API/Contracts/Http/IFhirHttpClientProvider.cs
+++ b/apps/gateway/Gateway.API/Contracts/Http/IFhirHttpClientProvider.cs
@@ -1,0 +1,14 @@
+namespace Gateway.API.Contracts.Http;
+
+/// <summary>
+/// Provides authenticated HTTP clients for Epic FHIR API.
+/// </summary>
+public interface IFhirHttpClientProvider
+{
+    /// <summary>
+    /// Gets an HTTP client with Bearer token attached.
+    /// </summary>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>An HTTP client configured with authentication.</returns>
+    Task<HttpClient> GetAuthenticatedClientAsync(CancellationToken ct = default);
+}

--- a/apps/gateway/Gateway.API/Contracts/Http/ITokenStrategyResolver.cs
+++ b/apps/gateway/Gateway.API/Contracts/Http/ITokenStrategyResolver.cs
@@ -1,0 +1,13 @@
+namespace Gateway.API.Contracts.Http;
+
+/// <summary>
+/// Resolves the appropriate token acquisition strategy for the current request.
+/// </summary>
+public interface ITokenStrategyResolver
+{
+    /// <summary>
+    /// Gets the token acquisition strategy for the current context.
+    /// </summary>
+    /// <returns>The appropriate token acquisition strategy.</returns>
+    ITokenAcquisitionStrategy Resolve();
+}

--- a/apps/gateway/Gateway.API/Gateway.API.csproj
+++ b/apps/gateway/Gateway.API/Gateway.API.csproj
@@ -7,6 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="Gateway.API.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <!-- Aspire Service Defaults -->
     <PackageReference Include="Aspire.StackExchange.Redis" Version="13.1.0" />
     <PackageReference Include="Aspire.Npgsql" Version="13.1.0" />
@@ -24,6 +28,9 @@
     <!-- Caching -->
     <PackageReference Include="Scrutor" Version="5.0.2" />
     <PackageReference Include="Microsoft.Extensions.Caching.Hybrid" Version="9.3.0" />
+
+    <!-- JWT / OAuth -->
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.2.1" />
 
     <!-- OpenAPI -->
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.0" />

--- a/apps/gateway/Gateway.API/Middleware/CdsHookTokenMiddleware.cs
+++ b/apps/gateway/Gateway.API/Middleware/CdsHookTokenMiddleware.cs
@@ -1,0 +1,74 @@
+using System.Text.Json;
+
+namespace Gateway.API.Middleware;
+
+/// <summary>
+/// Middleware that extracts FHIR access tokens from CDS Hook request payloads.
+/// </summary>
+public sealed class CdsHookTokenMiddleware
+{
+    private readonly RequestDelegate _next;
+    private readonly ILogger<CdsHookTokenMiddleware> _logger;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CdsHookTokenMiddleware"/> class.
+    /// </summary>
+    /// <param name="next">The next middleware in the pipeline.</param>
+    /// <param name="logger">Logger for diagnostic output.</param>
+    public CdsHookTokenMiddleware(RequestDelegate next, ILogger<CdsHookTokenMiddleware> logger)
+    {
+        _next = next;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Invokes the middleware.
+    /// </summary>
+    /// <param name="context">The HTTP context.</param>
+    public async Task InvokeAsync(HttpContext context)
+    {
+        // Only process CDS Hooks requests
+        if (context.Request.Path.StartsWithSegments("/cds-hooks") &&
+            context.Request.Method == HttpMethods.Post)
+        {
+            await ExtractAndStoreFhirTokenAsync(context);
+        }
+
+        await _next(context);
+    }
+
+    private async Task ExtractAndStoreFhirTokenAsync(HttpContext context)
+    {
+        try
+        {
+            // Enable buffering so the body can be read multiple times
+            context.Request.EnableBuffering();
+
+            using var reader = new StreamReader(context.Request.Body, leaveOpen: true);
+            var body = await reader.ReadToEndAsync();
+            context.Request.Body.Position = 0; // Reset for downstream handlers
+
+            if (string.IsNullOrEmpty(body))
+            {
+                return;
+            }
+
+            using var doc = JsonDocument.Parse(body);
+
+            if (doc.RootElement.TryGetProperty("fhirAuthorization", out var fhirAuth) &&
+                fhirAuth.TryGetProperty("access_token", out var tokenElement))
+            {
+                var token = tokenElement.GetString();
+                if (!string.IsNullOrEmpty(token))
+                {
+                    context.Items["FhirAccessToken"] = token;
+                    _logger.LogDebug("Extracted FHIR access token from CDS Hook request");
+                }
+            }
+        }
+        catch (JsonException ex)
+        {
+            _logger.LogWarning(ex, "Failed to parse CDS Hook request body for token extraction");
+        }
+    }
+}

--- a/apps/gateway/Gateway.API/Services/Http/CdsHookTokenStrategy.cs
+++ b/apps/gateway/Gateway.API/Services/Http/CdsHookTokenStrategy.cs
@@ -1,0 +1,32 @@
+using Gateway.API.Contracts.Http;
+using Microsoft.AspNetCore.Http;
+
+namespace Gateway.API.Services.Http;
+
+/// <summary>
+/// Token strategy that extracts the access token from CDS Hook request context.
+/// </summary>
+public sealed class CdsHookTokenStrategy : ITokenAcquisitionStrategy
+{
+    private readonly IHttpContextAccessor _httpContextAccessor;
+
+    /// <summary>
+    /// Initializes a new instance of <see cref="CdsHookTokenStrategy"/>.
+    /// </summary>
+    /// <param name="httpContextAccessor">HTTP context accessor for reading request context.</param>
+    public CdsHookTokenStrategy(IHttpContextAccessor httpContextAccessor)
+    {
+        _httpContextAccessor = httpContextAccessor;
+    }
+
+    /// <inheritdoc />
+    public bool CanHandle =>
+        _httpContextAccessor.HttpContext?.Items.ContainsKey("FhirAccessToken") == true;
+
+    /// <inheritdoc />
+    public Task<string?> AcquireTokenAsync(CancellationToken ct = default)
+    {
+        var token = _httpContextAccessor.HttpContext?.Items["FhirAccessToken"] as string;
+        return Task.FromResult(token);
+    }
+}

--- a/apps/gateway/Gateway.API/Services/Http/FhirHttpClientProvider.cs
+++ b/apps/gateway/Gateway.API/Services/Http/FhirHttpClientProvider.cs
@@ -1,0 +1,51 @@
+using System.Net.Http.Headers;
+using Gateway.API.Contracts.Http;
+
+namespace Gateway.API.Services.Http;
+
+/// <summary>
+/// Provides HTTP clients authenticated for Epic FHIR API access.
+/// </summary>
+public sealed class FhirHttpClientProvider : IFhirHttpClientProvider
+{
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly ITokenStrategyResolver _tokenResolver;
+    private readonly ILogger<FhirHttpClientProvider> _logger;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="FhirHttpClientProvider"/> class.
+    /// </summary>
+    /// <param name="httpClientFactory">Factory for creating HTTP clients.</param>
+    /// <param name="tokenResolver">Resolver for token acquisition strategies.</param>
+    /// <param name="logger">Logger for diagnostic output.</param>
+    public FhirHttpClientProvider(
+        IHttpClientFactory httpClientFactory,
+        ITokenStrategyResolver tokenResolver,
+        ILogger<FhirHttpClientProvider> logger)
+    {
+        _httpClientFactory = httpClientFactory;
+        _tokenResolver = tokenResolver;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public async Task<HttpClient> GetAuthenticatedClientAsync(CancellationToken ct = default)
+    {
+        var client = _httpClientFactory.CreateClient("EpicFhir");
+
+        var strategy = _tokenResolver.Resolve();
+        var token = await strategy.AcquireTokenAsync(ct);
+
+        if (token is not null)
+        {
+            client.DefaultRequestHeaders.Authorization =
+                new AuthenticationHeaderValue("Bearer", token);
+        }
+        else
+        {
+            _logger.LogWarning("No access token acquired for FHIR request");
+        }
+
+        return client;
+    }
+}

--- a/apps/gateway/Gateway.API/Services/Http/JwtBackendTokenStrategy.cs
+++ b/apps/gateway/Gateway.API/Services/Http/JwtBackendTokenStrategy.cs
@@ -1,0 +1,157 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Net.Http.Json;
+using System.Security.Claims;
+using System.Security.Cryptography;
+using System.Text.Json;
+using Gateway.API.Configuration;
+using Gateway.API.Contracts.Http;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Options;
+using Microsoft.IdentityModel.Tokens;
+
+namespace Gateway.API.Services.Http;
+
+/// <summary>
+/// Token strategy that acquires tokens via JWT-based client credentials flow.
+/// Used for backend services without user context.
+/// </summary>
+public sealed class JwtBackendTokenStrategy : ITokenAcquisitionStrategy
+{
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly EpicFhirOptions _options;
+    private readonly IMemoryCache _tokenCache;
+    private readonly ILogger<JwtBackendTokenStrategy> _logger;
+    private const string CacheKey = "EpicAccessToken";
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="JwtBackendTokenStrategy"/> class.
+    /// </summary>
+    /// <param name="httpClientFactory">Factory for creating HTTP clients.</param>
+    /// <param name="options">Epic FHIR configuration options.</param>
+    /// <param name="tokenCache">Memory cache for storing tokens.</param>
+    /// <param name="logger">Logger instance.</param>
+    public JwtBackendTokenStrategy(
+        IHttpClientFactory httpClientFactory,
+        IOptions<EpicFhirOptions> options,
+        IMemoryCache tokenCache,
+        ILogger<JwtBackendTokenStrategy> logger)
+    {
+        _httpClientFactory = httpClientFactory;
+        _options = options.Value;
+        _tokenCache = tokenCache;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public bool CanHandle => true; // Fallback strategy, always can handle
+
+    /// <inheritdoc />
+    public async Task<string?> AcquireTokenAsync(CancellationToken ct = default)
+    {
+        // Check cache first
+        if (_tokenCache.TryGetValue(CacheKey, out string? cached))
+        {
+            _logger.LogDebug("Using cached Epic access token");
+            return cached;
+        }
+
+        try
+        {
+            var jwt = GenerateClientAssertion();
+            var token = await ExchangeJwtForTokenAsync(jwt, ct);
+
+            if (token is not null)
+            {
+                // Cache for 55 minutes (tokens typically valid for 60)
+                _tokenCache.Set(CacheKey, token, TimeSpan.FromMinutes(55));
+                _logger.LogInformation("Acquired and cached new Epic access token");
+            }
+
+            return token;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to acquire Epic access token");
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Exchanges a JWT client assertion for an access token.
+    /// </summary>
+    /// <param name="jwt">The signed JWT client assertion.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>The access token or null if the exchange failed.</returns>
+    private async Task<string?> ExchangeJwtForTokenAsync(string jwt, CancellationToken ct)
+    {
+        using var client = _httpClientFactory.CreateClient();
+
+        var content = new FormUrlEncodedContent(new Dictionary<string, string>
+        {
+            ["grant_type"] = "client_credentials",
+            ["client_assertion_type"] = "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+            ["client_assertion"] = jwt
+        });
+
+        var response = await client.PostAsync(_options.TokenEndpoint, content, ct);
+        response.EnsureSuccessStatusCode();
+
+        var json = await response.Content.ReadFromJsonAsync<JsonElement>(cancellationToken: ct);
+        return json.GetProperty("access_token").GetString();
+    }
+
+    /// <summary>
+    /// Generates a JWT client assertion for Epic OAuth.
+    /// </summary>
+    /// <returns>A signed JWT string.</returns>
+    internal string GenerateClientAssertion()
+    {
+        var now = DateTime.UtcNow;
+        var tokenHandler = new JwtSecurityTokenHandler();
+
+        var claims = new[]
+        {
+            new Claim(JwtRegisteredClaimNames.Iss, _options.ClientId),
+            new Claim(JwtRegisteredClaimNames.Sub, _options.ClientId),
+            new Claim(JwtRegisteredClaimNames.Aud, _options.TokenEndpoint ?? ""),
+            new Claim(JwtRegisteredClaimNames.Jti, Guid.NewGuid().ToString()),
+        };
+
+        // Load private key
+        var privateKey = LoadPrivateKey();
+        var signingCredentials = new SigningCredentials(
+            new RsaSecurityKey(privateKey),
+            GetSigningAlgorithm(_options.SigningAlgorithm));
+
+        var tokenDescriptor = new SecurityTokenDescriptor
+        {
+            Subject = new ClaimsIdentity(claims),
+            Expires = now.AddMinutes(5), // JWT valid for 5 minutes
+            SigningCredentials = signingCredentials
+        };
+
+        var token = tokenHandler.CreateToken(tokenDescriptor);
+        return tokenHandler.WriteToken(token);
+    }
+
+    private RSA LoadPrivateKey()
+    {
+        if (string.IsNullOrEmpty(_options.PrivateKeyPath))
+        {
+            throw new InvalidOperationException("PrivateKeyPath is not configured");
+        }
+
+        var rsa = RSA.Create();
+        var keyPem = File.ReadAllText(_options.PrivateKeyPath);
+        rsa.ImportFromPem(keyPem);
+        return rsa;
+    }
+
+    private static string GetSigningAlgorithm(string algorithm) => algorithm switch
+    {
+        "RS256" => SecurityAlgorithms.RsaSha256,
+        "RS384" => SecurityAlgorithms.RsaSha384,
+        "RS512" => SecurityAlgorithms.RsaSha512,
+        _ => SecurityAlgorithms.RsaSha384
+    };
+}


### PR DESCRIPTION
## Summary

Implements dual OAuth authentication for Epic FHIR R4 API with strategy pattern. CDS Hook requests use the provided `fhirAuthorization.access_token`, while backend services use JWT-based client credentials flow with token caching.

## Changes

- **Token Strategies** — `CdsHookTokenStrategy` extracts tokens from CDS Hook context; `JwtBackendTokenStrategy` handles JWT generation with RS384 signing and 55-minute token caching
- **Token Resolution** — `TokenStrategyResolver` selects strategy based on request context (CDS Hook priority, JWT fallback)
- **HTTP Client Provider** — `FhirHttpClientProvider` attaches Bearer tokens to authenticated HttpClient instances
- **FHIR Client Refactor** — Removed `accessToken` parameter from all IFhirHttpClient methods; auth handled internally
- **CDS Middleware** — `CdsHookTokenMiddleware` extracts FHIR tokens from CDS Hook request payloads

## Test Plan

Unit tests cover all new components with 46 new tests. Integration verified with full test suite.

---

**Results:** Tests 102 ✓ · Build 0 errors
**Design:** [docs/designs/2026-01-28-epic-fhir-integration.md](docs/designs/2026-01-28-epic-fhir-integration.md)